### PR TITLE
add fall back reading units database from package

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,2 +1,2 @@
 exportPattern("^ud.*")
-useDynLib(udunits2, R_ut_are_convertible, R_ut_convert, R_ut_get_name, R_ut_get_symbol, R_ut_is_parseable, R_ut_set_encoding)
+useDynLib(udunits2, R_ut_are_convertible, R_ut_convert, R_ut_get_name, R_ut_get_symbol, R_ut_is_parseable, R_ut_set_encoding, R_ut_reinit)

--- a/R/ud.functions.R
+++ b/R/ud.functions.R
@@ -1,6 +1,4 @@
 .onLoad <- function(pkg, lib) {
-	#if (!(udunits2:::ud.is.parseable("m")))
-	library.dynam("udunits2", "udunits2", .libPaths())
 	if (!(ud.is.parseable("m"))) {
 		p0 = system.file("share/udunits2.xml", package="udunits2")
 		cat(paste0("udunits2 system database not loaded; reading shipped version from\n", p0, "\n"))

--- a/R/ud.functions.R
+++ b/R/ud.functions.R
@@ -1,7 +1,7 @@
-.onLoad <- function(pkg, lib) {
+.onAttach <- function(libname, pkgname) {
 	if (!(ud.is.parseable("m"))) {
 		p0 = system.file("share/udunits2.xml", package="udunits2")
-		cat(paste0("udunits2 system database not loaded; reading shipped version from\n", p0, "\n"))
+		packageStartupMessage("udunits2 system database not loaded; reading shipped version from\n", p0, "\n")
 		.C(R_ut_reinit, as.character(p0))
 		stopifnot(ud.is.parseable("m"))
 	}

--- a/R/ud.functions.R
+++ b/R/ud.functions.R
@@ -1,4 +1,4 @@
-.onAttach <- function(libname, pkgname) {
+.onLoad <- function(libname, pkgname) {
 	if (!(ud.is.parseable("m"))) {
 		p0 = system.file("share/udunits2.xml", package="udunits2")
 		.C(R_ut_reinit, as.character(p0))

--- a/R/ud.functions.R
+++ b/R/ud.functions.R
@@ -1,9 +1,11 @@
 .onAttach <- function(libname, pkgname) {
 	if (!(ud.is.parseable("m"))) {
 		p0 = system.file("share/udunits2.xml", package="udunits2")
-		packageStartupMessage("udunits2 system database not loaded; reading shipped version from\n", p0, "\n")
 		.C(R_ut_reinit, as.character(p0))
-		stopifnot(ud.is.parseable("m"))
+		if (ud.is.parseable("m"))
+			packageStartupMessage("udunits2 system database not loaded; reading shipped version from ", p0)
+		else
+			packageStartupMessage("failed to load system file ", p0, " : udunits2 will not work properly")
 	}
 }
 

--- a/R/ud.functions.R
+++ b/R/ud.functions.R
@@ -1,3 +1,14 @@
+.onLoad <- function(pkg, lib) {
+	#if (!(udunits2:::ud.is.parseable("m")))
+	library.dynam("udunits2", "udunits2", .libPaths())
+	if (!(ud.is.parseable("m"))) {
+		p0 = system.file("share/udunits2.xml", package="udunits2")
+		cat(paste0("udunits2 system database not loaded; reading shipped version from\n", p0, "\n"))
+		.C(R_ut_reinit, as.character(p0))
+		stopifnot(ud.is.parseable("m"))
+	}
+}
+
 ud.are.convertible <-
 function(u1, u2) {
   if (! (ud.is.parseable(u1) && ud.is.parseable(u2))) {

--- a/src/udunits2_R.c
+++ b/src/udunits2_R.c
@@ -8,11 +8,13 @@
 
 #include <R.h>
 #include <udunits2.h>
-#include <stdio.h>
+/* EJP: outcommented */
+/* #include <stdio.h> */
 
 static int module_initialized = 0;
 ut_system *sys = NULL;
 static ut_encoding enc;
+static char xml_path[256] = "";
 
 /* From the enum comments in udunits2.h */
 const char * ut_status_strings[] = {
@@ -40,10 +42,20 @@ void handle_error(const char *calling_function) {
   error("Error in function %s: %s", calling_function, ut_status_strings[stat]);
 }
 
+void R_ut_reinit(const char **path) { /* try to reboot the init with a new path to the database */
+	if (strlen(*path) > 255)
+  		error("path too long");
+	else {
+		module_initialized = 0;
+		strncpy(xml_path, *path, 255);
+		/* Rprintf("path reset to %s\n", (char *) xml_path); */
+	}
+}
+
 void R_ut_init(void) {
   if (! module_initialized) {
     ut_set_error_message_handler(ut_ignore);
-    sys = ut_read_xml(NULL);
+    sys = ut_read_xml(xml_path[0] == '\0' ? NULL : xml_path);
     ut_set_error_message_handler(ut_write_to_stderr);
     enc = UT_UTF8;
     module_initialized = 1;

--- a/src/udunits2_R.c
+++ b/src/udunits2_R.c
@@ -8,13 +8,12 @@
 
 #include <R.h>
 #include <udunits2.h>
-/* EJP: outcommented */
-/* #include <stdio.h> */
+#include <stdio.h> /* FILENAME_MAX */
 
 static int module_initialized = 0;
 ut_system *sys = NULL;
 static ut_encoding enc;
-static char xml_path[256] = "";
+static char xml_path[FILENAME_MAX] = "";
 
 /* From the enum comments in udunits2.h */
 const char * ut_status_strings[] = {
@@ -43,11 +42,11 @@ void handle_error(const char *calling_function) {
 }
 
 void R_ut_reinit(const char **path) { /* try to reboot the init with a new path to the database */
-	if (strlen(*path) > 255)
-  		error("path too long");
+	if (strlen(*path) > FILENAME_MAX - 1)
+  		error("path length too large for this operating system");
 	else {
 		module_initialized = 0;
-		strncpy(xml_path, *path, 255);
+		strncpy(xml_path, *path, FILENAME_MAX - 1);
 		/* Rprintf("path reset to %s\n", (char *) xml_path); */
 	}
 }


### PR DESCRIPTION
I have udunits2 in /usr/local; if UDUNITS2_XML_PATH is not set, udunits2 loads fine, but finds no units, without giving an error. This PR makes it fall back to the xml database shipped with the R package (which is not up-to-date with udunits 2.2.20, btw).
