### PR TITLE
make warnings less worrying to R users with binary package installs

### DIFF
--- a/R/ud.functions.R
+++ b/R/ud.functions.R
@@ -5,15 +5,24 @@
   if (!ud.have.unit.system()) {
     ## Failing that, override it with the in-package XML file
     p0 <- system.file("share/udunits2.xml", package="udunits2")
-    packageStartupMessage("udunits2 system database: ", p0)
     Sys.setenv(UDUNITS2_XML_PATH=p0)
     .C('R_ut_init', as.integer(1))
     ## If *that* fails, give the user some instructions for how to remedy
     ## the problem
     if (!ud.have.unit.system()) {
-      packageStartupMessage("Failed: udunits2 will not work properly. Please set the UDUNITS2_XML_PATH environment variable *before* attempting to load the package")
+      packageStartupMessage(
+	  "Failed to read udunitssystem database: udunits2 will not work properly.\nPlease set the UDUNITS2_XML_PATH environment variable before attempting to load the package")
     }
   }
+}
+
+.onAttach <- function(libname, pkgname) {
+	msg <- "udunits system database read"
+    p0 <- Sys.getenv("UDUNITS2_XML_PATH")
+	if (p0 != "") {
+		msg <- paste(msg, "from", p0)
+    } 
+	packageStartupMessage(msg)
 }
 
 ud.are.convertible <-

--- a/R/ud.functions.R
+++ b/R/ud.functions.R
@@ -1,13 +1,13 @@
 .onLoad <- function(libname, pkgname) {
   ## By default, configure udunits with path set (presumably) by the
   ## user through the UDUNITS2_XML_PATH environment variable
-  .C('R_ut_init')
+  .C('R_ut_init', as.integer(0))
   if (!ud.have.unit.system()) {
     ## Failing that, override it with the in-package XML file
     p0 <- system.file("share/udunits2.xml", package="udunits2")
-    packageStartupMessage("Failed to load udunits2 system database: reading shipped version from ", p0)
+    packageStartupMessage("udunits2 system database: ", p0)
     Sys.setenv(UDUNITS2_XML_PATH=p0)
-    .C('R_ut_init')
+    .C('R_ut_init', as.integer(1))
     ## If *that* fails, give the user some instructions for how to remedy
     ## the problem
     if (!ud.have.unit.system()) {

--- a/src/udunits2_R.c
+++ b/src/udunits2_R.c
@@ -40,19 +40,20 @@ void handle_error(const char *calling_function) {
   error("Error in function %s: %s", calling_function, ut_status_strings[stat]);
 }
 
-void R_ut_init(void) {
+void R_ut_init(int *print_warning_on_failure) {
   ut_status stat;
 
-  ut_set_error_message_handler(ut_write_to_stderr);
+  ut_set_error_message_handler((ut_error_message_handler) Rvprintf);
   if (sys != NULL) {
     ut_free_system(sys);
   }
   ut_set_error_message_handler(ut_ignore);
   sys = ut_read_xml(NULL);
-  ut_set_error_message_handler(ut_write_to_stderr);
+  ut_set_error_message_handler((ut_error_message_handler) Rvprintf);
   if (sys == NULL) {
     stat = ut_get_status();
-    ut_handle_error_message("Warning in R_ut_init: %s", ut_status_strings[stat]);
+    if (*print_warning_on_failure)
+		ut_handle_error_message("Warning in R_ut_init: %s\n", ut_status_strings[stat]);
     return;
   }
   enc = UT_UTF8;
@@ -92,9 +93,10 @@ void R_ut_set_encoding(const char * const *enc_string) {
 
 void R_ut_is_parseable(char * const *units_string, int *parseable) {
   ut_unit *result;
+  int one = 1;
 
   if (sys == NULL) {
-    R_ut_init();
+    R_ut_init(&one);
   }
 
   ut_trim(*units_string, enc);
@@ -111,9 +113,10 @@ void R_ut_is_parseable(char * const *units_string, int *parseable) {
 
 void R_ut_are_convertible(char * const *ustring1, char * const *ustring2, int *convertible) {
   ut_unit *u1, *u2;
+  int one = 1;
 
   if (sys == NULL) {
-    R_ut_init();
+    R_ut_init(&one);
   }
 
   ut_trim(*ustring1, enc); ut_trim(*ustring2, enc);
@@ -137,9 +140,10 @@ void R_ut_are_convertible(char * const *ustring1, char * const *ustring2, int *c
 void R_ut_convert(const double *x, int *count, char * const *units_from, char * const *units_to, double *rv) {
   ut_unit *from, *to;
   cv_converter *conv;
+  int one = 1;
 
   if (sys == NULL) {
-    R_ut_init();
+    R_ut_init(&one);
   }
 
   ut_trim(*units_from, enc); ut_trim(*units_to, enc);

--- a/src/udunits2_R.c
+++ b/src/udunits2_R.c
@@ -40,7 +40,7 @@ void handle_error(const char *calling_function) {
   error("Error in function %s: %s", calling_function, ut_status_strings[stat]);
 }
 
-void R_ut_init(int *print_warning_on_failure) {
+void R_ut_init(const int *print_warning_on_failure) {
   ut_status stat;
 
   ut_set_error_message_handler((ut_error_message_handler) Rvprintf);


### PR DESCRIPTION
This PR tries to do two the following:
1. avoid using `stderr` (see "Writing R extensions", search for stderr)
2. avoid warnings for Mac and Windows users who do binary install.
3. guarantee a silent load when using `suppressPackageStartupMessage(library(udunits2))`
