### PR TITLE
Add support for building from source on any Windows machine.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@ CONTRIBUTING.rst
 autom4te.cache/
 Dockerfile
 .travis.yml
+^windows

--- a/configure.win
+++ b/configure.win
@@ -1,2 +1,0 @@
-mkdir -p ${R_PACKAGE_DIR}/share
-cp -r ${UDUNITS2_HOME}/share/udunits ${R_PACKAGE_DIR}/share

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,1 +1,16 @@
-PKG_LIBS = -ludunits2 -lexpat
+PKG_CPPFLAGS = -I../windows/udunits-2.2.20/include
+PKG_LIBS = -L../windows/udunits-2.2.20/lib${R_ARCH} \
+	-ludunits2 -lexpat
+
+all: clean winlibs
+
+winlibs:
+	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
+	mkdir -p ../inst
+	rm -Rf ../inst/share
+	cp -r ../windows/udunits-2.2.20/share ../inst/
+
+clean:
+	rm -Rf $(SHLIB) $(OBJECTS)
+
+.PHONY: all winlibs clean

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,0 +1,8 @@
+# Build against mingw-w64 build of udunits
+if(!file.exists("../windows/udunits-2.2.20/include/udunits.h")){
+  if(getRversion() < "3.3.0") setInternet2()
+  download.file("https://github.com/rwinlib/udunits/archive/v2.2.20.zip", "lib.zip", quiet = TRUE)
+  dir.create("../windows", showWarnings = FALSE)
+  unzip("lib.zip", exdir = "../windows")
+  unlink("lib.zip")
+}


### PR DESCRIPTION
This will make the package build from source on any Windows user or server, not just CRAN. Fully tested.
